### PR TITLE
Remove the `raise: false` condition

### DIFF
--- a/app/controllers/devise/saml_sessions_controller.rb
+++ b/app/controllers/devise/saml_sessions_controller.rb
@@ -3,7 +3,7 @@ require "ruby-saml"
 class Devise::SamlSessionsController < Devise::SessionsController
   include DeviseSamlAuthenticatable::SamlConfig
   unloadable if Rails::VERSION::MAJOR < 4
-  skip_before_filter :verify_authenticity_token, raise: false
+  skip_before_filter :verify_authenticity_token
 
   def new
     idp_entity_id = get_idp_entity_id(params)


### PR DESCRIPTION
For some reason, Rails 4.2.7.1 ignores this `skip_before_filter` if the `raise: false` condition is present.